### PR TITLE
Upgrade modifier capabilities to 3.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          - ember-lts-3.16
-          - ember-lts-3.20
+          - ember-lts-3.22
           - ember-release
           - ember-beta
           - ember-canary

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="https://badge.fury.io/js/ember-focus-trap"><img src="https://badge.fury.io/js/ember-focus-trap.svg" alt="NPM version"></a>
 </p>
 
-
 **Ember Focus Trap**: A Ember modifier to trap your focus.
 
 [View the docs here](https://josemarluedke.github.io/ember-focus-trap/).
@@ -22,28 +21,21 @@ There may come a time when you find it important to trap focus within a DOM node
 
 Please read the [focus-trap](https://github.com/davidtheclark/focus-trap) documentation to understand what a focus trap is, what happens when a focus trap is activated, and what happens when one is deactivated.
 
-Compatibility
-------------------------------------------------------------------------------
+## Compatibility
 
-* Ember.js v3.16 or above
-* Ember CLI v2.13 or above
-* Node.js v10 or above
+- Ember.js v3.22 or above
+- Ember CLI v2.13 or above
+- Node.js v10 or above
 
-
-Installation
-------------------------------------------------------------------------------
+## Installation
 
 ```
 ember install ember-focus-trap
 ```
 
-
-Usage
-------------------------------------------------------------------------------
-
+## Usage
 
 [See demos and read the documentation here](https://josemarluedke.github.io/ember-focus-trap).
-
 
 ```hbs
 <div {{focus-trap}}>
@@ -84,14 +76,10 @@ Usage
 </div>
 ```
 
-
-Contributing
-------------------------------------------------------------------------------
+## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
-
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/addon/modifiers/focus-trap.js
+++ b/addon/modifiers/focus-trap.js
@@ -3,7 +3,7 @@ import { createFocusTrap as CreateFocusTrap } from 'focus-trap';
 
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13'),
+    capabilities: capabilities('3.22'),
 
     createModifier() {
       return {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,18 +8,10 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.16',
+        name: 'ember-lts-3.22',
         npm: {
           devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
+            'ember-source': '~3.22.2',
           },
         },
       },


### PR DESCRIPTION
This addon now requires Ember v3.22 due to the new capabilities.