### PR TITLE
Add back support for Ember 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          - ember-lts-3.22
+          - ember-lts-3.16
+          - ember-lts-3.20
           - ember-release
           - ember-beta
           - ember-canary

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Please read the [focus-trap](https://github.com/davidtheclark/focus-trap) docume
 
 ## Compatibility
 
-- Ember.js v3.22 or above
-- Ember CLI v2.13 or above
-- Node.js v10 or above
+* Ember.js v3.16 or above
+* Ember CLI v2.13 or above
+* Node.js v10 or above
 
 ## Installation
 

--- a/addon/modifiers/focus-trap.js
+++ b/addon/modifiers/focus-trap.js
@@ -1,9 +1,14 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
 import { createFocusTrap as CreateFocusTrap } from 'focus-trap';
+import { dependencySatisfies, macroCondition } from '@embroider/macros';
 
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.22'),
+    capabilities: capabilities(
+      macroCondition(dependencySatisfies('ember-source', '^3.22.0'))
+        ? '3.22'
+        : '3.13'
+    ),
 
     createModifier() {
       return {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,10 +8,18 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.22',
+        name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
-            'ember-source': '~3.22.2',
+            'ember-source': '~3.16.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@embroider/macros": "^0.41.0",
     "ember-auto-import": "^1.11.2",
     "ember-cli-babel": "^7.26.3",
     "ember-modifier-manager-polyfill": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,6 +1314,31 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/macros@^0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.41.0.tgz#3e78b6f388d7229906abf4c75edfff8bb0208aca"
+  integrity sha512-QISzwEEfLsskZeL0jyZDs1RoQSotwBWj+4upTogNHuxQP5j/9H3IMG/3QB1gh8GEpbudATb/cS4NDYK3UBxufw==
+  dependencies:
+    "@embroider/shared-internals" "0.41.0"
+    assert-never "^1.1.0"
+    ember-cli-babel "^7.23.0"
+    lodash "^4.17.10"
+    resolve "^1.8.1"
+    semver "^7.3.2"
+
+"@embroider/shared-internals@0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.41.0.tgz#2553f026d4f48ea1fd11235501feb63bf49fa306"
+  integrity sha512-fiqUVB6cfh2UBEFE4yhT5EzagkZ1Q26+OhBV0nJszFEJZx4DqVIb3pxSSZ8P+HhpxuJsQ2XpMA/j02ZPFZfbdQ==
+  dependencies:
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^7.0.1"
+    lodash "^4.17.10"
+    pkg-up "^3.1.0"
+    resolve-package-path "^1.2.2"
+    semver "^7.3.2"
+    typescript-memoize "^1.0.0-alpha.3"
+
 "@embroider/test-setup@^0.40.0":
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.40.0.tgz#bff8e7d780c1ba1a349f9e51605c9668a8f2c65d"


### PR DESCRIPTION
As discussed in https://github.com/josemarluedke/ember-focus-trap/pull/33#issuecomment-847974000, this introduces a conditional to support Ember 3.16+ while still using the latest modifier capabilities when possible. `@embroider/macros` was chosen for this instead of the usual `ember-compatibility-helpers`, as that seems to be the more future-proof solution to me, especially allowing an easier transition to an eventual native "v2" addon.