### PR TITLE
Make passed `focusTrapOptions` immutable

### DIFF
--- a/addon/modifiers/focus-trap.js
+++ b/addon/modifiers/focus-trap.js
@@ -29,7 +29,8 @@ export default setModifierManager(
         },
       }
     ) {
-      state.focusTrapOptions = focusTrapOptions || {};
+      // treat the original focusTrapOptions as immutable, so do a shallow copy here
+      state.focusTrapOptions = { ...focusTrapOptions } || {};
       if (typeof isActive !== 'undefined') {
         state.isActive = isActive;
       }


### PR DESCRIPTION
Recent CI runs of ember-bootstrap for Ember canary and beta started to fail because of deprecations, raised by mutating the `{{hash}}` object inside of this modifier when it is used to pass `focusTrapOptions` as in https://github.com/josemarluedke/ember-focus-trap#with-focus-trap-options. This deprecation was recently added to Ember in https://github.com/emberjs/ember.js/pull/19548. The change here treats that object as immutable.