### PR TITLE
Fix capabilities semver range for Ember 4

### DIFF
--- a/addon/modifiers/focus-trap.js
+++ b/addon/modifiers/focus-trap.js
@@ -5,7 +5,7 @@ import { dependencySatisfies, macroCondition } from '@embroider/macros';
 export default setModifierManager(
   () => ({
     capabilities: capabilities(
-      macroCondition(dependencySatisfies('ember-source', '^3.22.0'))
+      macroCondition(dependencySatisfies('ember-source', '^3.22.0 || >= 4.0'))
         ? '3.22'
         : '3.13'
     ),


### PR DESCRIPTION
I have seen deprecation warning when running Ember 4 with this addon, as the existing semver range was not correctly accounting for the higher major version (my fault in a previous PR).