### PR TITLE
Add missing support for additional elements/containers

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -12,6 +12,7 @@ Pass any of the options available in focus-trap's createOptions. [See
 documentation](https://github.com/davidtheclark/focus-trap#focustrap--createfocustrapelement-createoptions).
 
 ## isActive
+
 Type: Boolean, optional
 
 By default, the FocusTrap activates when the element renders.
@@ -20,11 +21,13 @@ If, however, you want to control when FocusTrap is activated or deactivated,
 you can use this option.
 
 ## isPaused
+
 Type: Boolean, optional
 
 If you would like to pause or unpause the focus trap (see [focus-trap's documentation](https://github.com/davidtheclark/focus-trap#focustrappause)), toggle this argument.
 
 ## shouldSelfFocus
+
 Type: Boolean, optional
 
 If you would like to initially focus in the element in which the modifier is
@@ -34,3 +37,11 @@ being applied.
 accomplish that by adding `tabindex="-1"`.
 
 <aside>This options has no effect if something is passed in `initialFocus` under `focusTrapOptions`.</aside>
+
+## additionalElements
+
+Type: Array, optional
+
+If needed, additional elements or containers can be added where focus-trap needs to be applied to. For example, absolutely/fixed-positioned dropdowns or popovers placed within a wormhole/placholder that need to be included in said focus-trap.
+
+As mentioned within [focus-trap's documentation](https://github.com/focus-trap/focus-trap#createfocustrapelement-createoptions), the order determines where the focus will go after the last tabbable element of a DOM node/selector is reached.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -33,10 +33,11 @@ Type: Boolean, optional
 If you would like to initially focus in the element in which the modifier is
 being applied.
 
-**Important:** For the focus in the container to work, you must make it focusable. You can
-accomplish that by adding `tabindex="-1"`.
+**Important:**
 
-<aside>This options has no effect if something is passed in `initialFocus` under `focusTrapOptions`.</aside>
+- For the focus in the container to work, you must make it focusable. You can
+  accomplish that by adding `tabindex="-1"`.
+- This options has no effect if something is passed in `initialFocus` under `focusTrapOptions`.
 
 ## additionalElements
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -42,6 +42,6 @@ accomplish that by adding `tabindex="-1"`.
 
 Type: Array, optional
 
-If needed, additional elements or containers can be added where focus-trap needs to be applied to. For example, absolutely/fixed-positioned dropdowns or popovers placed within a wormhole/placholder that need to be included in said focus-trap.
+If needed, additional elements or containers can be added where focus-trap needs to be applied to. For example, absolutely/fixed-positioned dropdowns or popovers placed within a wormhole/placeholder that need to be included in said focus-trap.
 
 As mentioned within [focus-trap's documentation](https://github.com/focus-trap/focus-trap#createfocustrapelement-createoptions), the order determines where the focus will go after the last tabbable element of a DOM node/selector is reached.

--- a/packages/ember-focus-trap/src/modifiers/focus-trap.js
+++ b/packages/ember-focus-trap/src/modifiers/focus-trap.js
@@ -18,7 +18,8 @@ export default setModifierManager(() => {
         isActive: true,
         isPaused: false,
         shouldSelfFocus: false,
-        focusTrap: undefined
+        focusTrap: undefined,
+        additionalElements: undefined
       };
     },
 
@@ -31,6 +32,7 @@ export default setModifierManager(() => {
           isPaused,
           shouldSelfFocus,
           focusTrapOptions,
+          additionalElements = [],
           _createFocusTrap
         }
       }
@@ -62,7 +64,10 @@ export default setModifierManager(() => {
         state.focusTrapOptions.returnFocusOnDeactivate = true;
       }
 
-      state.focusTrap = createFocusTrap(element, state.focusTrapOptions);
+      state.focusTrap = createFocusTrap(
+        [element, ...additionalElements],
+        state.focusTrapOptions
+      );
 
       if (state.isActive) {
         state.focusTrap.activate();

--- a/packages/ember-focus-trap/src/modifiers/focus-trap.js
+++ b/packages/ember-focus-trap/src/modifiers/focus-trap.js
@@ -18,8 +18,7 @@ export default setModifierManager(() => {
         isActive: true,
         isPaused: false,
         shouldSelfFocus: false,
-        focusTrap: undefined,
-        additionalElements: undefined
+        focusTrap: undefined
       };
     },
 
@@ -32,7 +31,7 @@ export default setModifierManager(() => {
           isPaused,
           shouldSelfFocus,
           focusTrapOptions,
-          additionalElements = [],
+          additionalElements,
           _createFocusTrap
         }
       }
@@ -65,7 +64,9 @@ export default setModifierManager(() => {
       }
 
       state.focusTrap = createFocusTrap(
-        [element, ...additionalElements],
+        typeof additionalElements !== 'undefined'
+          ? [element, ...additionalElements]
+          : element,
         state.focusTrapOptions
       );
 

--- a/packages/test-app/tests/integration/modifiers/focus-trap-test.js
+++ b/packages/test-app/tests/integration/modifiers/focus-trap-test.js
@@ -39,7 +39,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -66,7 +66,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button id="initial-focusee">Some button</button>
+            <button type="button" id="initial-focusee">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -89,7 +89,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -113,7 +113,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -139,7 +139,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -159,7 +159,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -182,7 +182,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -211,7 +211,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -240,7 +240,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -277,7 +277,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -312,7 +312,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -347,7 +347,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -372,7 +372,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -401,7 +401,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
               _createFocusTrap=this.fakeFocusTrap
             }}
           >
-            <button>Some button</button>
+            <button type="button">Some button</button>
           </div>`
       );
       assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
@@ -442,7 +442,7 @@ module('Integration | Modifier | focus-trap', function (hooks) {
                   _createFocusTrap=this.fakeFocusTrap
                 }}
               >
-                <button>Some button</button>
+                <button type="button">Some button</button>
               </div>
             {{/if}}`
       );

--- a/packages/test-app/tests/integration/modifiers/focus-trap-test.js
+++ b/packages/test-app/tests/integration/modifiers/focus-trap-test.js
@@ -54,6 +54,34 @@ module('Integration | Modifier | focus-trap', function (hooks) {
       assert.equal(this.instance.activate.callCount, 1, 'should have called');
     });
 
+    test('activation with additional elements', async function (assert) {
+      await render(
+        hbs`<div
+            data-test
+            {{focus-trap
+              additionalElements=(array "#foo" "#bar")
+              focusTrapOptions=(hash onDeactivate=this.noop)
+              _createFocusTrap=this.fakeFocusTrap
+            }}
+          >
+            <button type="button">Some button</button>
+          </div>`
+      );
+      assert.equal(this.fakeFocusTrap.callCount, 1, 'should have called once');
+
+      assert.ok(
+        this.fakeFocusTrap.calledWithExactly(
+          [find('[data-test]'), '#foo', '#bar'],
+          {
+            onDeactivate: noop,
+            returnFocusOnDeactivate: true
+          }
+        ),
+        'should have called with the element and options'
+      );
+      assert.equal(this.instance.activate.callCount, 1, 'should have called');
+    });
+
     test('activation with initialFocus as selector', async function (assert) {
       await render(
         hbs`<div


### PR DESCRIPTION
As mentioned within https://github.com/josemarluedke/ember-focus-trap/issues/71: adding support for additional elements/containers.