### PR TITLE
Add Ember v6 Peer Support

### DIFF
--- a/packages/ember-focus-trap/package.json
+++ b/packages/ember-focus-trap/package.json
@@ -20,7 +20,7 @@
     "prepare": "yarn build"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0 || ^5.0.0"
+    "ember-source": ">= 4.0.0"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0",


### PR DESCRIPTION
Changing this to the format in the current ember-cli blueprint to support the brand new ember 6.0.0 release.